### PR TITLE
HH-79393: fix error for create and edit vacancies

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -180,16 +180,16 @@ HTTP code | type | value | описание
 [редактировании](employer_vacancies.md#edit) вакансии могут быть возвращены
 следующие ошибки:
 
-HTTP code | type | value | описание
-----------|------|-------|---------
-400 | vacancies | *field_name* | ошибка в поле вакансии, где *field_name* – ключ поля верхнего уровня
-403 | vacancies | not_enough_purchased_services | купленных услуг для публикации или обновления данного типа вакансии не достаточно
-403 | vacancies | quota_exceeded | квота менеджера на публикацию данного типа вакансии закончилась
-403 | vacancies | duplicate | аналогичная вакансия уже опубликована, данную ошибку можно форсировано отключить (при [добавлении](employer_vacancies.md#creation-ignore-duplicates) и [редактировании](employer_vacancies.md#edit-ignore-duplicates))
-403 | vacancies | creation_forbidden | публикация вакансий недоступна текущему менеджеру
-403 | vacancies | unavailable_for_archived | редактирование недоступно для архивной вакансии
-403 | vacancies | conflict_changes | конфликтные изменения данных вакансии ([подробнее](employer_vacancies.md#edit_more))
-403 | vacancies | can_not_accept_kids | публикация вакансий для поиска соискателей от 14 лет недоступна ([подробнее](employer_vacancies_accept_kids.md#accept-kids))
+HTTP code | type | value | reason | описание
+----------|------|-------|-------|---------
+400 | bad_json_data | *field_name* | *reason* | ошибка в поле вакансии, где *field_name* – ключ поля верхнего уровня, поле reason может не присутствовать
+403 | vacancies | not_enough_purchased_services | | купленных услуг для публикации или обновления данного типа вакансии не достаточно
+403 | vacancies | quota_exceeded | | квота менеджера на публикацию данного типа вакансии закончилась
+403 | vacancies | duplicate | | аналогичная вакансия уже опубликована, данную ошибку можно форсировано отключить (при [добавлении](employer_vacancies.md#creation-ignore-duplicates) и [редактировании](employer_vacancies.md#edit-ignore-duplicates))
+403 | vacancies | creation_forbidden | | публикация вакансий недоступна текущему менеджеру
+403 | vacancies | unavailable_for_archived | | редактирование недоступно для архивной вакансии
+403 | vacancies | conflict_changes | | конфликтные изменения данных вакансии ([подробнее](employer_vacancies.md#edit_more))
+403 | vacancies | can_not_accept_kids | | публикация вакансий для поиска соискателей от 14 лет недоступна ([подробнее](employer_vacancies_accept_kids.md#accept-kids))
 
 
 <a name="vacancies-prolongate"></a>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-79393

если переданное поле не правильное, то выдается не ошибка с типом vacancies, а ошибка с типом bad_json_data. Так же может выдаваться причина, но не всегда. Сейчас выдается только 1: email_in_description. Решила, что возможные причины описывать не стоит, пишите, если не согласны