### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hhru/api-reviewers


### PR DESCRIPTION
Добавила codeowners для автоназначения ревьюверов
<!-- 
При добавлении/изменении документации нужно не забывать править английскую документацию.
Если вы добавляете большой блок документации необходимо создать задачу на перевод на Маркетинг 
(за подробностями обращайтесь в команду API)
-->
