### PR TITLE
Актуализировали ссылки на /dictionaries и /applicant_comments/{applicant_id}

### DIFF
--- a/docs/employer_vacancy_upgrades.md
+++ b/docs/employer_vacancy_upgrades.md
@@ -60,7 +60,7 @@ GET /vacancies/{vacancy_id}/upgrades
 
 Имя | Тип | Описание
 ---- | --- | ---
-vacancy_billing_type.id | string | тип публикации (справочник [vacancy_billing_type](https://github.com/hhru/api/blob/master/docs/dictionaries.md))
+vacancy_billing_type.id | string | тип публикации (справочник [vacancy_billing_type](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get))
 vacancy_billing_type.name | string | название типа публикации
 vacancy_billing_type.description | string | описание типа вакансии
 actions | array | список возможных действий
@@ -76,7 +76,7 @@ url | string или null | ссылка на действие
 cart_id | integer или null | идентификатор заказа, ожидающего активации. Присутствует для `type=activate` 
 price | object или null | стоимость. Присутствует для `type=buy`
 price.amount | double | значение цены
-price.currency | string | Идентификатор валюты (справочник [currency](https://github.com/hhru/api/blob/master/docs/dictionaries.md))
+price.currency | string | Идентификатор валюты (справочник [currency](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get))
 
 <a name="action_types"></a>
 Значения типов действия `actions.type`

--- a/docs/resumes_search.md
+++ b/docs/resumes_search.md
@@ -27,12 +27,12 @@
   необходимо указывать весь набор (триаду) параметров. 
 
 * `text.logic` – описывает, как производится поиск. Справочник с возможными
-  значениями: `resume_search_logic` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  значениями: `resume_search_logic` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `text.field` – описывает, где должны встречаться слова из поисковой фразы
   `text`. В параметре text.field можно укзать несколько значений через запятую,
   например – `?text.field=education,keywords`. Справочник с возможными
-  значениями: `resume_search_fields` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  значениями: `resume_search_fields` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `text.period` – период для поиска в опыте работы. Параметр имеет смысл
   только для `text.field` равного одному из: `experience`, `experience_company`,
@@ -47,7 +47,7 @@
   переехать, поменять это поведение можно указанием поля `relocation`.
 
 * `relocation` — готовность к переезду. Справочник с возможными
-  значениями: `resume_search_relocation` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  значениями: `resume_search_relocation` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
   Необходимо указывать вместе с параметром `area`.
 
 * `period` — в днях, ищет резюме опубликованные за указанный период.
@@ -63,46 +63,46 @@
   с параметром `date_from`. Нельзя передавать вместе с параметром `period`.
 
 * `education_level` —  уровень образования. Справочник с возможными значениями:
-  `education_level` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md). Если не указан, поиск
+  `education_level` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). Если не указан, поиск
   ведется без ограничений на уровень образования.
 
 * `employment` — тип занятости.
   Справочник с возможными значениями: `employment` в
-  [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md). Можно указать несколько значений.
+  [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). Можно указать несколько значений.
 
 * `experience` — опыт работы. Справочник с возможными значениями: `experience`
-  в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `skill` - ключевые навыки. Указывается один или несколько идентификаторов
   ключевых навыков. Значения можно получить из поля `id` в
   [подсказке по ключевым навыкам](https://github.com/hhru/api/blob/master/docs/suggests.md#key-skills).
 
 * `gender` — пол. Справочник с возможными значениями: `gender` в
-  [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md). По умолчанию вне зависимости от значения
+  [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). По умолчанию вне зависимости от значения
   параметра будут найдены резюме, в которых пол не указан, убрать такие резюме
   можно с помощью `label=only_with_gender`.
 
 <a name="resume_search_label"></a>
 * `label` — дополнительный фильтр. Справочник с возможными значениями:
-  `resume_search_label` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md). Можно указать
+  `resume_search_label` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). Можно указать
   несколько значений.
 
 * `language` — знание языка. Можно указать несколько значений. Задается в
   формате language.level, где:
      * `language` — значение из справочника [/languages](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1languages/get),
      * `level` — значение из справочника `language_level`
-       [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+       [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `metro` — линия, либо станция метро. Справочник с возможными значениями:
   [/metro](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1metro/get).
 
 * `currency` — код валюты. Справочник с возможными значениями: `currency`
-  (ключ code) в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  (ключ code) в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `salary_from`, `salary_to` — диапазон желаемой заработной платы (ЗП), от и до. Обратите внимание, по умолчанию в выдачу добавляются так же резюме с неуказанной ЗП, для выдачи резюме только с указанной ЗП используйте специальный [label](#resume_search_label) "only_with_salary"
 
 * `schedule` — график работы. Справочник с возможными значениями:
-  `schedule` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md). Можно указать несколько
+  `schedule` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). Можно указать несколько
   значений.
 
 * `specialization` — профобласть или специализация. Справочник с возможными
@@ -110,7 +110,7 @@
   значений. Будет заменен профессиональными ролями (параметр `professional_role`), в настоящее время работает в режиме обратной совместимости.
 
 * `order_by` — сортировка списка резюме. Справочник с возможными значениями:
-  `resume_search_order` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  `resume_search_order` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
 * `citizenship` — страна желаемого гражданства. Возможные значения можно
   посмотреть в справочнике стран. Возможно указание нескольких значений.
@@ -133,7 +133,7 @@
   совпадения слов, но еще и слова, начинающиеся с `text`. По умолчанию стоит значение `false`.
   
 * `driver_license_types` — категории водительских прав. Справочник с возможными значениями:
-  `driver_license_types` в [/dictionaries](https://github.com/hhru/api/blob/master/docs/dictionaries.md).
+  `driver_license_types` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
   
 * `vacancy_id` — идентификатор вакансии для поиска похожих резюме. Необходимо передавать идентификатор активной или архивной вакансии работодателя.
 
@@ -353,7 +353,7 @@
 
 Дополнительно работодателю выдаются следующие поля:
 * `owner.comments.url` — содержит url, GET запрос на который возвращает
-[список комментариев к владельцу резюме](https://github.com/hhru/api/blob/master/docs/applicant_comments.md#list)
+[список комментариев к владельцу резюме](https://api.hh.ru/openapi/redoc#tag/Kommentarii-k-soiskatelyu/paths/~1applicant_comments~1%7Bapplicant_id%7D/get)
 * `owner.comments.counters.total` — общее количество таких комментариев
 * `last_negotiation` — информация о последнем статусе в истории откликов/приглашений. Поля `employer_state` и
 `created_at` аналогичны соответствующим полям в

--- a/docs_eng/employer_vacancies.md
+++ b/docs_eng/employer_vacancies.md
@@ -676,7 +676,7 @@ to change the specialisation you will have to send a full list.
  accept_incomplete_resumes  | whether it is possible to apply with an incomplete resume   
  branded_template.id        | <a name="branded-template-field"></a> branded vacancy description from [directory](https://api.hh.ru/openapi/en/redoc#tag/Employer-info/paths/~1employers~1%7Bemployer_id%7D~1vacancy_branded_templates/get) |
 languages[].id | string | language ID. [Languages](languages.md) directory entries.
-languages[].level.id | string | field Id. [anguage_level](dictionaries.md) directory entry.
+languages[].level.id | string | field Id. [Language_level](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get) directory entry.
 
 The remaining fields are read-only or can only be set during initial publication.
 

--- a/docs_eng/employer_vacancy_upgrades.md
+++ b/docs_eng/employer_vacancy_upgrades.md
@@ -60,7 +60,7 @@ with the following indicated for each `items` element:
 
 Name | Type | Description
 ---- | --- | ---
-vacancy_billing_type.id | string | publication type (directory [vacancy_billing_type](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md))
+vacancy_billing_type.id | string | publication type (directory [vacancy_billing_type](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get))
 vacancy_billing_type.name | string | name of publication type
 vacancy_billing_type.description | string | description of vacancy type
 actions | array | list of possible actions
@@ -76,7 +76,7 @@ url | string or null | link to action
 cart_id | integer or null | ID of the order awaiting activation. Shown for `type=activate`
 price | object or null | price. Shown for `type=buy`
 price.amount | double | price amount
-price.currency | string | currency ID (directory [currency](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md))
+price.currency | string | currency ID (directory [currency](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get))
 
 <a name="action_types"></a>
 `actions.type` values for action types

--- a/docs_eng/resumes_search.md
+++ b/docs_eng/resumes_search.md
@@ -28,13 +28,13 @@ Some parameters take multiple values: `key=value&key=value`.
   `400 Bad request` will be returned.
 
 * `text.logic` – describes how the search works. Directory with possible values:
-  `resume_search_logic` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  `resume_search_logic` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 
 * `text.field` – describes where words from the `text` search
   phrase should be found. In the `text.field` parameter you can
   indicate several values separated by commas, e.g.
   `?text.field=education,keywords`. Directory with possible values:
-  `resume_search_fields` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  `resume_search_fields` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 
 * `text.period` – a period for searching in work experience. The parameter
   works only when `text.field` equals one of: `experience`, `experience_company`,
@@ -71,7 +71,7 @@ For example:
   indicated regions or those who ready to move to such regions
   are selected by default. Enter field `relocation` to change this behavior.
 * `relocation` – willingness to relocate. Directory with possible values:
-  `resume_search_relocation` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md). You can
+  `resume_search_relocation` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). You can
   indicate it only with `area` parameter.
 * `period` – in days, searches CVs published in the given time period.
   If not indicated, the search is performed without any restrictions on
@@ -84,40 +84,40 @@ For example:
   `YYYY-MM-DD` or with up-to-the-second precision `YYYY-MM-DDThh:mm:ss±hhmm`. You can indicate it only with the
   `date_from` parameter. You can't indicate it with the `period` parameter.
 * `education_level` – a level of education. Directory with possible values:
-  `education_level` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md). If not indicated,
+  `education_level` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). If not indicated,
   the search is performed without any restrictions on the education level.
 * `employment` – employment type.
   Directory with possible values: `employment` in
-  [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md). You can indicate several values.
+  [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). You can indicate several values.
 * `experience` – work experience. Directory with possible values: `experience`
-  in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 * `skill` – key skills. At least one key skill identifier is indicated. You
   can get values from the `id` field in the
   [key skills suggestion](https://github.com/hhru/api/blob/master/docs_eng/suggests.md#key-skills).
 * `gender` – a gender. Directory with possible values: `gender` in
-  [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 <a name="resume_search_label"></a>
 * `label` – an extra filter. Directory with possible values:
-  `resume_search_label` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md). You can indicate
+  `resume_search_label` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). You can indicate
   several values.
 * `language` – knowledge of a language. You can indicate several values. It is
   set in the language.level format, where:
     * `language` is a value from the [/languages](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1languages/get) directory,
     * `level` is a value from the `language_level`
-      [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md) directory.
+      [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get) directory.
 * `metro` – a metro line or station. Directory with possible values:
   [/metro](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1metro/get).
 * `currency` – a currency code. Directory with possible values: `currency`
-  (code key) in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  (code key) in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 * `salary_from`, `salary_to` – desired salary range, from...to.
 * `schedule` – work schedule. Directory with possible values:
-  `schedule` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md). You can indicate
+  `schedule` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). You can indicate
   several values.
 * `specialization` – a professional area or specialization. Directory with
   possible values: [/specializations](https://github.com/hhru/api/blob/master/docs_eng/specializations.md). You can indicate
   several values.
 * `order_by` – CV list sorting. Directory with possible values:
-  `resume_search_order` in [/dictionaries](https://github.com/hhru/api/blob/master/docs_eng/dictionaries.md).
+  `resume_search_order` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 * `per_page` – the number of results per page (cannot exceed 50).
 * `page` – a page number.
 * `citizenship` – a desired country of citizenship. You can find possible
@@ -296,5 +296,5 @@ CV fields are similar to the
 The employer will have additional fields:
 
 * `owner.comments.url` containing url. GET request on it will return
-  [applicant comments list of CV owner](https://github.com/hhru/api/blob/master/docs_eng/applicant_comments.md#list).
+  [applicant comments list of CV owner](https://api.hh.ru/openapi/en/redoc#tag/Applicant-comments/paths/~1applicant_comments~1%7Bapplicant_id%7D/get).
 * `owner.comments.counters.total` containing total comments amount.


### PR DESCRIPTION
<!-- 
При добавлении/изменении документации нужно не забывать править английскую документацию.
Если вы добавляете большой блок документации необходимо создать задачу на перевод на Маркетинг 
(за подробностями обращайтесь в команду API)
-->
