### PR TITLE
удалили specialization из поиска резюме

### DIFF
--- a/docs/resumes_search.md
+++ b/docs/resumes_search.md
@@ -105,10 +105,6 @@
   `schedule` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get). Можно указать несколько
   значений.
 
-* `specialization` — профобласть или специализация. Справочник с возможными
-  значениями: [/specializations](https://github.com/hhru/api/blob/master/docs/specializations.md). Можно указать несколько
-  значений. Будет заменен профессиональными ролями (параметр `professional_role`), в настоящее время работает в режиме обратной совместимости.
-
 * `order_by` — сортировка списка резюме. Справочник с возможными значениями:
   `resume_search_order` в [/dictionaries](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1dictionaries/get).
 
@@ -143,7 +139,7 @@
 
 * `professional_role` — профессиональная роль. Элемент справочника
   [professional_roles](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1professional_roles/get). Можно указать несколько
-  значений. Замена специализациям (параметр `specialization`)
+  значений.
 
 * `folder` — один или несколько идентификаторов папок с отобранными резюме.
 Если данный параметр передан, поиск будет ограничен содержимым указанных папок.

--- a/docs_eng/resumes_search.md
+++ b/docs_eng/resumes_search.md
@@ -113,9 +113,6 @@ For example:
 * `schedule` – work schedule. Directory with possible values:
   `schedule` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get). You can indicate
   several values.
-* `specialization` – a professional area or specialization. Directory with
-  possible values: [/specializations](https://github.com/hhru/api/blob/master/docs_eng/specializations.md). You can indicate
-  several values.
 * `order_by` – CV list sorting. Directory with possible values:
   `resume_search_order` in [/dictionaries](https://api.hh.ru/openapi/en/redoc#tag/Public-directories/paths/~1dictionaries/get).
 * `per_page` – the number of results per page (cannot exceed 50).


### PR DESCRIPTION
<!-- 
При добавлении/изменении документации нужно не забывать править английскую документацию.
Если вы добавляете большой блок документации необходимо создать задачу на перевод на Маркетинг 
(за подробностями обращайтесь в команду API)
-->
