### PR TITLE
HH-175079 remove few fields in employer_negotiations_statistics doc

### DIFF
--- a/docs/employer_negotiations_statistics.md
+++ b/docs/employer_negotiations_statistics.md
@@ -28,13 +28,11 @@ GET /employers/{employer_id}/negotiations_statistics
     "employer_statistics": {
         "received": 20,
         "viewed_percent": 23,
-        "viewed_percent_change": 10,
         "replied_percent": 0,
-        "replied_percent_change": -15,
         "average_reply_time": 1.0,
         "politeness": {
             "index": 62,
-            "index_change": -1,
+            "index_change": 0,
             "hint": "Ваш Индекс вежливости выше среднего — это хороший показатель, и все же он может быть лучше!",
             "description": "Индекс вежливости видят соискатели после отклика на вакансию. Компании с низким Индексом теряют доверие соискателей и рискуют пропустить подходящих кандидатов.",
             "article_url": "https://hh.ru/article/23734"
@@ -52,9 +50,7 @@ GET /employers/{employer_id}/negotiations_statistics
 |-----|-----|----------|
 | received | number | количество откликов на вакансии работодателя, полученных за последние `30 дней` (далее период) |
 | viewed_percent | number или null | процент прочитанных откликов на вакансии работодателя за период или `null` при отсутствии откликов |
-| viewed_percent_change | number или null | изменение viewed_percent по сравнению с предыдущим периодом или `null` при отсутствии откликов |
 | replied_percent | number или null | процент откликов на вакансии работодателя, перемещенных в любую другую [коллекцию](employer_negotiations.md#term-collection) с отправкой сообщения за период или `null` при отсутствии откликов |
-| replied_percent_change | number или null | изменение replied_percent по сравнению с предыдущим периодом или `null` при отсутствии откликов |
 | average_reply_time | number или null | среднее время в днях между получением отклика на вакансии работодателя и отправкой сообщения или `null` при отсутствии отправленных сообщений |
 | politeness | object или null | [Объект `politeness`](#employer_politeness_field) или `null`, если [индекс вежливости](https://hh.ru/article/23734) компании рассчитать нельзя, например,  пока нет ни одной вакансии или отклика |
 
@@ -63,13 +59,13 @@ GET /employers/{employer_id}/negotiations_statistics
 
 Содержит информацию об [индексе вежливости](https://hh.ru/article/23734) компании. 
 
-| Имя | Тип | Описание |
-|-----|-----|----------|
-| index | number | значение индекса вежливости компании |
-| index_change | number | изменение индекса вежливости компании по сравнению с предыдущим периодом |
-| hint | string | краткое описание текущего значения индекса вежливости компании |
-| description | string | краткое описание понятия индекса вежливости |
-| article_url | string | url статьи про индекс вежливости |
+| Имя | Тип | Описание                                                                            |
+|-----|-----|-------------------------------------------------------------------------------------|
+| index | number | значение индекса вежливости компании                                                |
+| index_change | number | Внимание! Параметр устарел, т.к. индекс вежливости расчитывается в реальном времени |
+| hint | string | краткое описание текущего значения индекса вежливости компании                      |
+| description | string | краткое описание понятия индекса вежливости                                         |
+| article_url | string | url статьи про индекс вежливости                                                    |
 
 
 ### Ошибки
@@ -100,9 +96,7 @@ GET /employers/{employer_id}/managers/{manager_id}/negotiations_statistics
     "manager_statistics": {
         "received": 20,
         "viewed_percent": 23,
-        "viewed_percent_change": 10,
         "replied_percent": 0,
-        "replied_percent_change": -15,
         "average_reply_time": 1.0,
         "politeness": {
             "index": 19,
@@ -124,9 +118,7 @@ GET /employers/{employer_id}/managers/{manager_id}/negotiations_statistics
 |-----|-----|----------|
 | received | number | количество откликов на вакансии менеджера, полученных за последние `30 дней` (далее период) |
 | viewed_percent | number или null | процент прочитанных откликов на вакансии менеджера за период или `null` при отсутствии откликов |
-| viewed_percent_change | number или null | изменение viewed_percent по сравнению с предыдущим периодом или `null` при отсутствии откликов |
 | replied_percent | number или null | процент откликов на вакансии менеджера, перемещенных в любую другую [коллекцию](employer_negotiations.md#term-collection) с отправкой сообщения за период или `null` при отсутствии откликов |
-| replied_percent_change | number или null | изменение replied_percent по сравнению с предыдущим периодом или `null` при отсутствии откликов |
 | average_reply_time | number или null | среднее время в днях между получением отклика на вакансии менеджера и отправкой сообщения или `null` при отсутствии отправленных сообщений |
 | politeness | object или null | [Объект `politeness`](#manager_politeness_field) или `null`, если [индекс вежливости](https://hh.ru/article/23734) менеджера рассчитать нельзя, например, у него пока нет ни одной вакансии или отклика |
 
@@ -138,7 +130,7 @@ GET /employers/{employer_id}/managers/{manager_id}/negotiations_statistics
 | Имя | Тип | Описание |
 |-----|-----|----------|
 | index | number | значение индекса вежливости менеджера |
-| index_change | number | изменение индекса вежливости менеджера по сравнению с предыдущим периодом |
+| index_change | number | Внимание! Параметр устарел, т.к. индекс вежливости расчитывается в реальном времени |
 | hint | string | краткое описание текущего значения индекса вежливости менеджера |
 | description | string | краткое описание понятия индекса вежливости |
 | article_url | string | url статьи про индекс вежливости |

--- a/docs_eng/employer_negotiations_statistics.md
+++ b/docs_eng/employer_negotiations_statistics.md
@@ -28,13 +28,11 @@ Successful server response is returned with `200 OK` code and contains:
     "employer_statistics": {
         "received": 20,
         "viewed_percent": 23,
-        "viewed_percent_change": 10,
         "replied_percent": 0,
-        "replied_percent_change": -15,
         "average_reply_time": 1.0,
         "politeness": {
             "index": 62,
-            "index_change": -1,
+            "index_change": 0,
             "hint": "You have a medium value of politeness index. This is good, but you can increase it.",
             "description": "An applicant see the politeness index after he has been responded to a vacancy. The companies with low politeness index lose the applicants trust and may miss suitable candidates.",
             "article_url": "https://hh.ru/article/23734"
@@ -50,9 +48,7 @@ Name | Type | Description
 --- | --- | --------
 received | number | number of responses to employer jobs received in the last `30 days` (the "Period")
 viewed_percent | number or null | percentage of read responses to the employer's jobs for the Period, or `null` if there are no responses
-viewed_percent_change | number or null | difference between the current viewed_percent value compared to the previous Period, or `null` if there are no responses
 replied_percent | number or null | percentage of responses to employer jobs that have been moved to any other [collection](employer_negotiations.md#term-collection) and accompanied by messages for a Period, or `null` if there are no responses 
-replied_percent_change | number or null | difference between the current replied_percent value compared to the previous Period, or `null` if there are no responses
 average_reply_time | number or null | average time in days between receiving a response to an employer job and sending a message, or `null` if no messages were sent
 politeness | object or null | [The object `politeness`](#employer_politeness_field) or `null`, if company [politeness index](https://hh.ru/article/23734)  is not calculated, for example,  the company has no vacancies or responses
 
@@ -64,7 +60,7 @@ Contains information about company [politeness index](https://hh.ru/article/2373
 Name | Type | Description
 -----|-----|----------
 index | number | company politeness index 
-index_change | number | company politeness index delta for the Period
+index_change | number | Attention! This param is deprecated, because politeness index is calculated in runtime
 hint | string | description about current value of politeness index
 description | string | short information about politeness index 
 article_url | string | url of orticle about politeness index 
@@ -96,9 +92,7 @@ Successful server response is returned with `200 OK` code and contains:
     "manager_statistics": {
         "received": 20,
         "viewed_percent": 23,
-        "viewed_percent_change": 10,
         "replied_percent": 0,
-        "replied_percent_change": -15,
         "average_reply_time": 1.0,
         "politeness": {
             "index": 19,
@@ -118,9 +112,7 @@ Name | Type | Description
 --- | --- | --------
 received | number | number of responses to manager jobs received in the last `30 days` (the "Period")
 viewed_percent | number или null | percentage of read responses to the manager's jobs for the Period, or `null` if there are no responses
-viewed_percent_change | number или null | difference between the current viewed_percent value compared to the previous Period, or `null` if there are no responses
 replied_percent | number или null | percentage of responses to manager jobs that have been moved to any other [collection](employer_negotiations.md#term-collection) and accompanied by messages for a Period, or `null` if there are no responses 
-replied_percent_change | number или null | difference between the current replied_percent value compared to the previous Period, or `null` if there are no responses
 average_reply_time | number или null | average time in days between receiving a response to a manager job and sending a message, or `null` if no messages were sent
 politeness | object or null | [The object `politeness`](#manager_politeness_field) or `null`, if manager [politeness index](https://hh.ru/article/23734)  is not calculated, for example, the manager has no vacancies or responses
 
@@ -132,7 +124,7 @@ Contains information about manager [politeness index](https://hh.ru/article/2373
 Name | Type | Description
 -----|-----|----------
 index | number | manager politeness index 
-index_change | number | manager politeness index delta for the Period
+index_change | number | Attention! This param is deprecated, because politeness index is calculated in runtime
 hint | string | description about current value of politeness index
 description | string | short information about politeness index 
 article_url | string | url of orticle about politeness index 


### PR DESCRIPTION
Переводим ИВ на новый бекенд, который расчитывается в рил тайме. Поэтому понятие `изменение *_percent по сравнению с предыдущим периодом` потеряло смысл, т.к. предыдущего периода теперь нет.